### PR TITLE
feat(gui): add black screen mode

### DIFF
--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -3,17 +3,20 @@ package gui
 import (
 	"context"
 	"fmt"
+	"image/color"
+	"time"
+
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/app"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/driver/desktop"
 	"fyne.io/fyne/v2/layout"
 	"fyne.io/fyne/v2/widget"
 	"github.com/lucaber/deckjoy/pkg/config"
 	"github.com/lucaber/deckjoy/pkg/service"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/image/colornames"
-	"time"
 )
 
 type GUI struct {
@@ -34,6 +37,20 @@ func (g *GUI) Run() {
 	g.window = g.app.NewWindow("DeckJoy")
 	g.window.SetFullScreen(true)
 
+	g.setBlackScreen(false)
+	g.window.ShowAndRun()
+}
+
+func (g *GUI) setBlackScreen(on bool) {
+	g.window.SetPadded(!on)
+	if on {
+		g.window.SetContent(g.buildBlackScreenUI())
+		return
+	}
+	g.window.SetContent(g.buildMainUI())
+}
+
+func (g *GUI) buildMainUI() fyne.CanvasObject {
 	errLabel := widget.NewLabel("")
 	startUSBButton := widget.NewButton("Start USB", func() {
 		g.deck.StartDaemon(context.Background())
@@ -71,17 +88,87 @@ func (g *GUI) Run() {
 	versionText := canvas.NewText(fmt.Sprintf("%s", config.Version), colornames.Gray)
 	versionText.TextSize = 8
 
-	g.window.SetContent(container.NewVBox(
+	blackScreenButton := newHiddenCursorButton("Black Screen", func() {
+		g.setBlackScreen(true)
+	})
+
+	return container.NewVBox(
 		widget.NewLabel(fmt.Sprintf("DeckJoy")),
 		startUSBButton,
 		startInputWindowButton,
+		blackScreenButton,
 		errLabel,
 		layout.NewSpacer(),
 		container.NewHBox(
 			layout.NewSpacer(),
 			versionText,
 		),
-	))
-
-	g.window.ShowAndRun()
+	)
 }
+
+type hiddenCursorButton struct {
+	widget.Button
+}
+
+func newHiddenCursorButton(label string, tapped func()) *hiddenCursorButton {
+	b := &hiddenCursorButton{}
+	b.Text = label
+	b.OnTapped = tapped
+	b.ExtendBaseWidget(b)
+	return b
+}
+
+func (b *hiddenCursorButton) Cursor() desktop.Cursor { return desktop.HiddenCursor }
+
+func (g *GUI) buildBlackScreenUI() fyne.CanvasObject {
+	return newTappableBlackRect(func() {
+		g.setBlackScreen(false)
+	})
+}
+
+// tappableBlackRect is a full-screen black widget that restores the main UI on any tap/touch.
+// It hides the mouse cursor immediately and fills the window with pure black.
+type tappableBlackRect struct {
+	widget.BaseWidget
+	onTap func()
+}
+
+func newTappableBlackRect(onTap func()) *tappableBlackRect {
+	r := &tappableBlackRect{onTap: onTap}
+	r.ExtendBaseWidget(r)
+	return r
+}
+
+func (r *tappableBlackRect) CreateRenderer() fyne.WidgetRenderer {
+	rect := canvas.NewRectangle(colornames.Black)
+	return &blackRectRenderer{rect: rect}
+}
+
+func (r *tappableBlackRect) Tapped(_ *fyne.PointEvent) {
+	if r.onTap != nil {
+		r.onTap()
+	}
+}
+
+func (r *tappableBlackRect) TappedSecondary(_ *fyne.PointEvent) {}
+
+// Cursor implements desktop.Cursorable — hides the mouse pointer immediately.
+func (r *tappableBlackRect) Cursor() desktop.Cursor { return desktop.HiddenCursor }
+
+func (r *tappableBlackRect) MouseIn(_ *desktop.MouseEvent)    {}
+func (r *tappableBlackRect) MouseMoved(_ *desktop.MouseEvent) {}
+func (r *tappableBlackRect) MouseOut()                        {}
+
+type blackRectRenderer struct {
+	rect *canvas.Rectangle
+}
+
+func (r *blackRectRenderer) Layout(size fyne.Size) {
+	r.rect.Move(fyne.NewPos(0, 0))
+	r.rect.Resize(size)
+}
+func (r *blackRectRenderer) MinSize() fyne.Size           { return fyne.NewSize(0, 0) }
+func (r *blackRectRenderer) Refresh()                     { r.rect.Refresh() }
+func (r *blackRectRenderer) BackgroundColor() color.Color { return color.Black }
+func (r *blackRectRenderer) Objects() []fyne.CanvasObject { return []fyne.CanvasObject{r.rect} }
+func (r *blackRectRenderer) Destroy()                     {}

--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -24,6 +24,8 @@ type GUI struct {
 	app         fyne.App
 	window      fyne.Window
 	inputWindow *InputWindow
+	mainUI      fyne.CanvasObject
+	blackUI     fyne.CanvasObject
 }
 
 func NewGUI(deck *service.Deck) *GUI {
@@ -36,6 +38,8 @@ func (g *GUI) Run() {
 	g.app = app.New()
 	g.window = g.app.NewWindow("DeckJoy")
 	g.window.SetFullScreen(true)
+	g.mainUI = g.buildMainUI()
+	g.blackUI = g.buildBlackScreenUI()
 
 	g.setBlackScreen(false)
 	g.window.ShowAndRun()
@@ -44,10 +48,16 @@ func (g *GUI) Run() {
 func (g *GUI) setBlackScreen(on bool) {
 	g.window.SetPadded(!on)
 	if on {
-		g.window.SetContent(g.buildBlackScreenUI())
+		if g.blackUI == nil {
+			g.blackUI = g.buildBlackScreenUI()
+		}
+		g.window.SetContent(g.blackUI)
 		return
 	}
-	g.window.SetContent(g.buildMainUI())
+	if g.mainUI == nil {
+		g.mainUI = g.buildMainUI()
+	}
+	g.window.SetContent(g.mainUI)
 }
 
 func (g *GUI) buildMainUI() fyne.CanvasObject {


### PR DESCRIPTION
Add a Black Screen action to the main UI for controller-only use.

When activated, DeckJoy replaces the normal interface with a fullscreen black view. Any touchscreen tap restores the normal controls.

The black screen fills the window and hides the cursor for a cleaner controller-only experience, especially on the Steam Deck OLED.

This change is limited to pkg/gui/gui.go and does not affect USB, controller, or daemon behavior.

Added follow-up fix: leaving black screen now reuses the previously built main UI instead of rebuilding it each time. This avoids spawning duplicate readiness polling goroutines during repeated black-screen toggles.