### PR TITLE
feat(setup): install scoped one-time polkit rule

### DIFF
--- a/pkg/daemon/server.go
+++ b/pkg/daemon/server.go
@@ -2,16 +2,17 @@ package daemon
 
 import (
 	context "context"
+	"net"
+	"os"
+	"syscall"
+	"time"
+
 	"github.com/lucaber/deckjoy/pkg/ipc"
 	"github.com/lucaber/deckjoy/pkg/setup"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"net"
-	"os"
-	"syscall"
-	"time"
 )
 
 type Server struct {
@@ -113,6 +114,12 @@ func NewServer(path string) *Server {
 }
 
 func (s *Server) Run() error {
+	// Daemon runs as root; install the polkit rule so future pkexec invocations
+	// don't prompt the user again.
+	if err := setup.InstallPolkitRuleAsRoot(); err != nil {
+		log.WithError(err).Warn("failed to install polkit rule")
+	}
+
 	l, err := net.Listen("unix", s.path)
 	defer func() {
 		_ = os.Remove(s.path)

--- a/pkg/setup/polkit.go
+++ b/pkg/setup/polkit.go
@@ -1,0 +1,89 @@
+package setup
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"strconv"
+	"strings"
+)
+
+const polkitRulePath = "/etc/polkit-1/rules.d/80-deckjoy.rules"
+
+// InstallPolkitRuleAsRoot writes the polkit rule directly. Must be called from
+// a process already running as root (e.g. the daemon).
+func InstallPolkitRuleAsRoot() error {
+	exePath, userName, err := getRuleInputs()
+	if err != nil {
+		return err
+	}
+
+	ruleContent := buildPolkitRule(exePath, userName)
+
+	if existing, err := os.ReadFile(polkitRulePath); err == nil {
+		if string(existing) == ruleContent {
+			return nil
+		}
+	}
+
+	return os.WriteFile(polkitRulePath, []byte(ruleContent), 0644)
+}
+
+func getRuleInputs() (exePath string, userName string, err error) {
+	exePath, err = os.Readlink("/proc/self/exe")
+	if err != nil {
+		return "", "", err
+	}
+
+	userName, err = getExpectedSubjectUser()
+	if err != nil {
+		return "", "", err
+	}
+
+	return exePath, userName, nil
+}
+
+func getExpectedSubjectUser() (string, error) {
+	// Default to deck for SteamOS environments.
+	userName := "deck"
+
+	// When called from the root daemon (started via pkexec), current user is root.
+	// In that case, prefer the original caller from PKEXEC_UID/SUDO_USER.
+	if os.Geteuid() == 0 {
+		if pkexecUID := os.Getenv("PKEXEC_UID"); pkexecUID != "" {
+			if pkexecUser, lookupErr := user.LookupId(pkexecUID); lookupErr == nil && pkexecUser.Username != "" {
+				userName = pkexecUser.Username
+				return userName, nil
+			}
+		}
+		if sudoUser := os.Getenv("SUDO_USER"); sudoUser != "" {
+			userName = sudoUser
+			return userName, nil
+		}
+		return userName, nil
+	}
+
+	if currentUser, currentUserErr := user.Current(); currentUserErr == nil && currentUser.Username != "" {
+		userName = currentUser.Username
+	}
+
+	return userName, nil
+}
+
+func buildPolkitRule(exePath string, userName string) string {
+	exePathQuoted := strconv.Quote(exePath)
+	userNameQuoted := strconv.Quote(userName)
+
+	return strings.TrimSpace(fmt.Sprintf(`
+// Allows DeckJoy GUI to start its own daemon with pkexec without repeated password prompts.
+polkit.addRule(function(action, subject) {
+    if (action.id == "org.freedesktop.policykit.exec" &&
+        action.lookup("program") == %s &&
+        subject.user == %s &&
+        subject.local &&
+        subject.active) {
+        return polkit.Result.YES;
+    }
+});
+`, exePathQuoted, userNameQuoted)) + "\n"
+}


### PR DESCRIPTION
This PR reduces repeated Start USB authentication prompts by installing a tightly scoped polkit rule after successful elevation.

Why:
- Current flow can require repetitive re-authentication.
- Reducing repeated prompts improves usability, especially for gaming-mode launch workflows.

What changed:
- Added polkit rule installer logic scoped to:
- current DeckJoy executable path
- current user
- active/local session constraints
- Daemon startup path installs/refreshes the rule from root context.
- Rule is written under /etc/polkit-1/rules.d/80-deckjoy.rules.

Behavior:
- First successful privileged launch still authenticates normally.
- Subsequent Start USB runs are auto-authorized by policy (including across restarts), as long as scope still matches.

Safety:
- No credential caching is introduced.
- Incorrect password does not persist anything.
- Rule install/update only happens after successful elevation.

Testing:
- Tested on Steam Deck gaming mode: after first successful auth, subsequent Start USB runs do not reprompt (including after deck reboot).
