### PR TITLE
fix(gui): use Fyne black screen for controller flow

### DIFF
--- a/pkg/gui/gui.go
+++ b/pkg/gui/gui.go
@@ -3,12 +3,14 @@ package gui
 import (
 	"context"
 	"fmt"
+	"image/color"
 	"time"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/app"
 	"fyne.io/fyne/v2/canvas"
 	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/driver/desktop"
 	"fyne.io/fyne/v2/layout"
 	"fyne.io/fyne/v2/widget"
 	"github.com/lucaber/deckjoy/pkg/config"
@@ -22,6 +24,7 @@ type GUI struct {
 	app         fyne.App
 	window      fyne.Window
 	inputWindow *InputWindow
+	mainContent fyne.CanvasObject
 }
 
 func NewGUI(deck *service.Deck) *GUI {
@@ -40,8 +43,8 @@ func (g *GUI) Run() {
 	startInputWindowButton := widget.NewButton("Show Mouse/Keyboard", func() {
 		g.showInputWindow(false)
 	})
-	startBlackScreenButton := widget.NewButton("Black Screen", func() {
-		g.showInputWindow(true)
+	startBlackScreenButton := newHiddenCursorButton("Black Screen", func() {
+		g.setFyneBlackScreen()
 	})
 	startInputWindowButton.Disable()
 	startBlackScreenButton.Disable()
@@ -73,7 +76,7 @@ func (g *GUI) Run() {
 	versionText := canvas.NewText(fmt.Sprintf("%s", config.Version), colornames.Gray)
 	versionText.TextSize = 8
 
-	g.window.SetContent(container.NewVBox(
+	g.mainContent = container.NewVBox(
 		widget.NewLabel(fmt.Sprintf("DeckJoy")),
 		startUSBButton,
 		startInputWindowButton,
@@ -84,10 +87,65 @@ func (g *GUI) Run() {
 			layout.NewSpacer(),
 			versionText,
 		),
-	))
+	)
+	g.window.SetContent(g.mainContent)
 
 	g.window.ShowAndRun()
 }
+
+func (g *GUI) setFyneBlackScreen() {
+	g.window.SetPadded(false)
+	blackRect := newTappableBlackRect(func() {
+		g.window.SetPadded(true)
+		g.window.SetContent(g.mainContent)
+	})
+	g.window.SetContent(blackRect)
+}
+
+type hiddenCursorButton struct {
+	widget.Button
+}
+
+func newHiddenCursorButton(label string, tapped func()) *hiddenCursorButton {
+	b := &hiddenCursorButton{}
+	b.Text = label
+	b.OnTapped = tapped
+	b.ExtendBaseWidget(b)
+	return b
+}
+
+func (b *hiddenCursorButton) Cursor() desktop.Cursor { return desktop.HiddenCursor }
+
+// tappableBlackRect is a full-screen black widget that restores the main UI on tap.
+type tappableBlackRect struct {
+	widget.BaseWidget
+	onTap func()
+}
+
+func newTappableBlackRect(onTap func()) *tappableBlackRect {
+	r := &tappableBlackRect{onTap: onTap}
+	r.ExtendBaseWidget(r)
+	return r
+}
+
+func (r *tappableBlackRect) CreateRenderer() fyne.WidgetRenderer {
+	rect := canvas.NewRectangle(color.Black)
+	return widget.NewSimpleRenderer(rect)
+}
+
+func (r *tappableBlackRect) Tapped(_ *fyne.PointEvent) {
+	if r.onTap != nil {
+		r.onTap()
+	}
+}
+
+func (r *tappableBlackRect) TappedSecondary(_ *fyne.PointEvent) {}
+
+func (r *tappableBlackRect) Cursor() desktop.Cursor { return desktop.HiddenCursor }
+
+func (r *tappableBlackRect) MouseIn(_ *desktop.MouseEvent)    {}
+func (r *tappableBlackRect) MouseMoved(_ *desktop.MouseEvent) {}
+func (r *tappableBlackRect) MouseOut()                        {}
 
 func (g *GUI) showInputWindow(blackScreen bool) {
 	go func() {


### PR DESCRIPTION
This PR keeps black-screen behavior in the main Fyne window when entered from the main menu, instead of routing that path through the SDL input window.

Why:
- In gaming-mode controller-first use, opening the SDL input window for black screen can be counterproductive.
- It can change touch behavior and interfere with controller passthrough expectations.
- Controller-first black screen is conceptually a simple UI state change, so Fyne is a better fit for that entry path.

What changed:
- Main-menu Black Screen now swaps to a Fyne full-screen black view.
- Tap restores the previous main content.
- Cursor hiding/transition behavior is handled in the Fyne path for cleaner UX. (I use cursor hiding on button hover so no cursor lingers)

What did not change:
- SDL keyboard/mouse workflow remains intact.
- No protocol/daemon/auth changes in this PR.

Testing:
- Built and tested on Steam Deck in gaming mode (non-Steam app launch).
- Verified controller-first black screen entry/exit behavior is stable.

Notes:
- This is intended as one half of a split approach:
- SDL black screen for keyboard path 
- Fyne black screen for controller-first path